### PR TITLE
Fix regex for attribute value codes

### DIFF
--- a/database/factories/AttributeValueFactory.php
+++ b/database/factories/AttributeValueFactory.php
@@ -16,7 +16,7 @@ class AttributeValueFactory extends Factory
     {
         return [
             'attribute_id' => Attribute::factory(),
-            'code' => $this->faker->unique()->regexify('[a-z0-9._]{8}'),
+            'code' => $this->faker->unique()->regexify('[a-z0-9_]{8}'),
             'name' => [
                 'en' => ucfirst($this->faker->word),
                 'pl' => ucfirst($this->faker->word),


### PR DESCRIPTION
## Summary
- fix regex for `AttributeValueFactory`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f44bc16f88320b7bda0287171a45e