### PR TITLE
Add attribute and attribute value controllers with tests

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,16 @@ use Gildsmith\Product\Controllers\Product\ProductIndexController;
 use Gildsmith\Product\Controllers\Product\ProductRestoreController;
 use Gildsmith\Product\Controllers\Product\ProductTrashedController;
 use Gildsmith\Product\Controllers\Product\ProductUpdateController;
+use Gildsmith\Product\Controllers\Attribute\AttributeCreateController;
+use Gildsmith\Product\Controllers\Attribute\AttributeDeleteController;
+use Gildsmith\Product\Controllers\Attribute\AttributeFindController;
+use Gildsmith\Product\Controllers\Attribute\AttributeIndexController;
+use Gildsmith\Product\Controllers\Attribute\AttributeUpdateController;
+use Gildsmith\Product\Controllers\AttributeValue\AttributeValueCreateController;
+use Gildsmith\Product\Controllers\AttributeValue\AttributeValueDeleteController;
+use Gildsmith\Product\Controllers\AttributeValue\AttributeValueFindController;
+use Gildsmith\Product\Controllers\AttributeValue\AttributeValueIndexController;
+use Gildsmith\Product\Controllers\AttributeValue\AttributeValueUpdateController;
 
 Route::prefix('products')->group(function () {
     Route::get('/', ProductIndexController::class);
@@ -19,4 +29,22 @@ Route::prefix('products')->group(function () {
     Route::patch('/{code}', ProductUpdateController::class);
     Route::delete('/{code}', ProductDeleteController::class);
     Route::post('/{code}/restore', ProductRestoreController::class);
+});
+
+Route::prefix('attributes')->group(function () {
+    Route::get('/', AttributeIndexController::class);
+    Route::post('/', AttributeCreateController::class);
+    Route::get('/{code}', AttributeFindController::class);
+    Route::put('/{code}', AttributeUpdateController::class);
+    Route::patch('/{code}', AttributeUpdateController::class);
+    Route::delete('/{code}', AttributeDeleteController::class);
+});
+
+Route::prefix('attribute-values')->group(function () {
+    Route::get('/', AttributeValueIndexController::class);
+    Route::post('/', AttributeValueCreateController::class);
+    Route::get('/{code}', AttributeValueFindController::class);
+    Route::put('/{code}', AttributeValueUpdateController::class);
+    Route::patch('/{code}', AttributeValueUpdateController::class);
+    Route::delete('/{code}', AttributeValueDeleteController::class);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,13 +2,6 @@
 
 declare(strict_types=1);
 
-use Gildsmith\Product\Controllers\Product\ProductCreateController;
-use Gildsmith\Product\Controllers\Product\ProductDeleteController;
-use Gildsmith\Product\Controllers\Product\ProductFindController;
-use Gildsmith\Product\Controllers\Product\ProductIndexController;
-use Gildsmith\Product\Controllers\Product\ProductRestoreController;
-use Gildsmith\Product\Controllers\Product\ProductTrashedController;
-use Gildsmith\Product\Controllers\Product\ProductUpdateController;
 use Gildsmith\Product\Controllers\Attribute\AttributeCreateController;
 use Gildsmith\Product\Controllers\Attribute\AttributeDeleteController;
 use Gildsmith\Product\Controllers\Attribute\AttributeFindController;
@@ -19,6 +12,13 @@ use Gildsmith\Product\Controllers\AttributeValue\AttributeValueDeleteController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueFindController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueIndexController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueUpdateController;
+use Gildsmith\Product\Controllers\Product\ProductCreateController;
+use Gildsmith\Product\Controllers\Product\ProductDeleteController;
+use Gildsmith\Product\Controllers\Product\ProductFindController;
+use Gildsmith\Product\Controllers\Product\ProductIndexController;
+use Gildsmith\Product\Controllers\Product\ProductRestoreController;
+use Gildsmith\Product\Controllers\Product\ProductTrashedController;
+use Gildsmith\Product\Controllers\Product\ProductUpdateController;
 
 Route::prefix('products')->group(function () {
     Route::get('/', ProductIndexController::class);

--- a/src/Controllers/Attribute/AttributeCreateController.php
+++ b/src/Controllers/Attribute/AttributeCreateController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Attribute;
+
+use Gildsmith\Contract\Product\AttributeInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class AttributeCreateController extends Controller
+{
+    public function __invoke(Request $request): AttributeInterface
+    {
+        /** @var Builder $builder */
+        $builder = resolve(AttributeInterface::class);
+
+        return $builder::forceCreate($request->all());
+    }
+}

--- a/src/Controllers/Attribute/AttributeDeleteController.php
+++ b/src/Controllers/Attribute/AttributeDeleteController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Attribute;
+
+use Gildsmith\Contract\Product\AttributeInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Controller;
+
+class AttributeDeleteController extends Controller
+{
+    public function __invoke(string $code): bool
+    {
+        /** @var Model&AttributeInterface $attribute */
+        $attribute = resolve(AttributeInterface::class)::where('code', $code)->firstOrFail();
+
+        return (bool) $attribute->delete();
+    }
+}

--- a/src/Controllers/Attribute/AttributeFindController.php
+++ b/src/Controllers/Attribute/AttributeFindController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Attribute;
+
+use Gildsmith\Contract\Product\AttributeInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Routing\Controller;
+
+class AttributeFindController extends Controller
+{
+    public function __invoke(string $code): ?AttributeInterface
+    {
+        /** @var Builder $builder */
+        $builder = resolve(AttributeInterface::class);
+
+        return $builder::where('code', $code)->first();
+    }
+}

--- a/src/Controllers/Attribute/AttributeIndexController.php
+++ b/src/Controllers/Attribute/AttributeIndexController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Attribute;
+
+use Gildsmith\Contract\Product\AttributeInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+
+class AttributeIndexController extends Controller
+{
+    public function __invoke(): Collection
+    {
+        /** @var Builder $builder */
+        $builder = resolve(AttributeInterface::class);
+
+        return $builder->get();
+    }
+}

--- a/src/Controllers/Attribute/AttributeUpdateController.php
+++ b/src/Controllers/Attribute/AttributeUpdateController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Attribute;
+
+use Gildsmith\Contract\Product\AttributeInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class AttributeUpdateController extends Controller
+{
+    public function __invoke(Request $request, string $code): AttributeInterface
+    {
+        /** @var Model&AttributeInterface $attribute */
+        $attribute = resolve(AttributeInterface::class)::where('code', $code)->firstOrFail();
+
+        $attribute->update($request->all());
+
+        return $attribute->fresh();
+    }
+}

--- a/src/Controllers/AttributeValue/AttributeValueCreateController.php
+++ b/src/Controllers/AttributeValue/AttributeValueCreateController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\AttributeValue;
+
+use Gildsmith\Contract\Product\AttributeValueInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class AttributeValueCreateController extends Controller
+{
+    public function __invoke(Request $request): AttributeValueInterface
+    {
+        /** @var Builder $builder */
+        $builder = resolve(AttributeValueInterface::class);
+
+        return $builder::forceCreate($request->all());
+    }
+}

--- a/src/Controllers/AttributeValue/AttributeValueDeleteController.php
+++ b/src/Controllers/AttributeValue/AttributeValueDeleteController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\AttributeValue;
+
+use Gildsmith\Contract\Product\AttributeValueInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Controller;
+
+class AttributeValueDeleteController extends Controller
+{
+    public function __invoke(string $code): bool
+    {
+        /** @var Model&AttributeValueInterface $value */
+        $value = resolve(AttributeValueInterface::class)::where('code', $code)->firstOrFail();
+
+        return (bool) $value->delete();
+    }
+}

--- a/src/Controllers/AttributeValue/AttributeValueFindController.php
+++ b/src/Controllers/AttributeValue/AttributeValueFindController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\AttributeValue;
+
+use Gildsmith\Contract\Product\AttributeValueInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Routing\Controller;
+
+class AttributeValueFindController extends Controller
+{
+    public function __invoke(string $code): ?AttributeValueInterface
+    {
+        /** @var Builder $builder */
+        $builder = resolve(AttributeValueInterface::class);
+
+        return $builder::where('code', $code)->first();
+    }
+}

--- a/src/Controllers/AttributeValue/AttributeValueIndexController.php
+++ b/src/Controllers/AttributeValue/AttributeValueIndexController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\AttributeValue;
+
+use Gildsmith\Contract\Product\AttributeValueInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+
+class AttributeValueIndexController extends Controller
+{
+    public function __invoke(): Collection
+    {
+        /** @var Builder $builder */
+        $builder = resolve(AttributeValueInterface::class);
+
+        return $builder->get();
+    }
+}

--- a/src/Controllers/AttributeValue/AttributeValueUpdateController.php
+++ b/src/Controllers/AttributeValue/AttributeValueUpdateController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\AttributeValue;
+
+use Gildsmith\Contract\Product\AttributeValueInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class AttributeValueUpdateController extends Controller
+{
+    public function __invoke(Request $request, string $code): AttributeValueInterface
+    {
+        /** @var Model&AttributeValueInterface $value */
+        $value = resolve(AttributeValueInterface::class)::where('code', $code)->firstOrFail();
+
+        $value->update($request->all());
+
+        return $value->fresh();
+    }
+}

--- a/tests/Feature/AttributeController.test.php
+++ b/tests/Feature/AttributeController.test.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Gildsmith\Product\Models\Attribute;
+
+it('lists attributes', function () {
+    Attribute::factory()->count(3)->create();
+
+    $response = $this->getJson('/attributes');
+
+    $response->assertOk()->assertJsonCount(3);
+});
+
+it('creates an attribute', function () {
+    $payload = [
+        'code' => 'color',
+        'name' => ['en' => 'Color', 'pl' => 'Kolor'],
+    ];
+
+    $response = $this->postJson('/attributes', $payload);
+
+    $response->assertCreated()->assertJsonPath('code', 'color');
+    $this->assertDatabaseHas('attributes', ['code' => 'color']);
+});
+
+it('shows an attribute', function () {
+    $attribute = Attribute::factory()->create();
+
+    $response = $this->getJson("/attributes/{$attribute->code}");
+
+    $response->assertOk()->assertJsonPath('code', $attribute->code);
+});
+
+it('updates an attribute', function () {
+    $attribute = Attribute::factory()->create();
+
+    $response = $this->putJson("/attributes/{$attribute->code}", [
+        'name' => ['en' => 'Updated', 'pl' => 'Zaktualizowany'],
+    ]);
+
+    $response->assertOk()->assertJsonPath('name.en', 'Updated');
+    $this->assertDatabaseHas('attributes', ['code' => $attribute->code, 'name->en' => 'Updated']);
+});
+
+it('deletes an attribute', function () {
+    $attribute = Attribute::factory()->create();
+
+    $response = $this->deleteJson("/attributes/{$attribute->code}");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertDatabaseMissing('attributes', ['code' => $attribute->code]);
+});

--- a/tests/Feature/AttributeValueController.test.php
+++ b/tests/Feature/AttributeValueController.test.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Gildsmith\Product\Models\Attribute;
+use Gildsmith\Product\Models\AttributeValue;
+
+it('lists attribute values', function () {
+    AttributeValue::factory()->count(3)->create();
+
+    $response = $this->getJson('/attribute-values');
+
+    $response->assertOk()->assertJsonCount(3);
+});
+
+it('creates an attribute value', function () {
+    $attribute = Attribute::factory()->create();
+
+    $payload = [
+        'attribute_id' => $attribute->id,
+        'code' => 'red',
+        'name' => ['en' => 'Red', 'pl' => 'Czerwony'],
+    ];
+
+    $response = $this->postJson('/attribute-values', $payload);
+
+    $response->assertCreated()->assertJsonPath('code', 'red');
+    $this->assertDatabaseHas('attribute_values', ['code' => 'red']);
+});
+
+it('shows an attribute value', function () {
+    $value = AttributeValue::factory()->create();
+
+    $response = $this->getJson("/attribute-values/{$value->code}");
+
+    $response->assertOk()->assertJsonPath('code', $value->code);
+});
+
+it('updates an attribute value', function () {
+    $value = AttributeValue::factory()->create();
+
+    $response = $this->putJson("/attribute-values/{$value->code}", [
+        'name' => ['en' => 'Updated', 'pl' => 'Zaktualizowany'],
+    ]);
+
+    $response->assertOk()->assertJsonPath('name.en', 'Updated');
+    $this->assertDatabaseHas('attribute_values', ['code' => $value->code, 'name->en' => 'Updated']);
+});
+
+it('deletes an attribute value', function () {
+    $value = AttributeValue::factory()->create();
+
+    $response = $this->deleteJson("/attribute-values/{$value->code}");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertDatabaseMissing('attribute_values', ['code' => $value->code]);
+});


### PR DESCRIPTION
## Summary
- add CRUD controllers for attributes and attribute values
- wire up routes for attributes and attribute values
- cover new HTTP endpoints with feature tests

## Testing
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_688d75ec7f7c8320aff2e931d71723d7