### PR TITLE
Add comprehensive Product facade tests

### DIFF
--- a/tests/Unit/Facades/Product.test.php
+++ b/tests/Unit/Facades/Product.test.php
@@ -6,10 +6,19 @@ use Gildsmith\Contract\Product\ProductInterface;
 use Gildsmith\Product\Exception\MissingSoftDeletesException;
 use Gildsmith\Product\Facades\ProductFacade as ProductFacadeConcrete;
 use Gildsmith\Product\Models\Product as ProductModel;
+use Gildsmith\Product\Models\Blueprint;
 use Gildsmith\Support\Facades\Product as ProductFacade;
 use Illuminate\Database\Eloquent\Model;
 
+if (! interface_exists(\Gildsmith\Contract\Facades\ProductFacadeInterface::class)) {
+    class_alias(\Gildsmith\Contract\Facades\Product::class, \Gildsmith\Contract\Facades\ProductFacadeInterface::class);
+}
+
 covers(ProductFacadeConcrete::class);
+
+beforeEach(function () {
+    app()->bind(\Gildsmith\Contract\Facades\Product::class, fn () => app(\Gildsmith\Contract\Facades\ProductFacadeInterface::class));
+});
 
 describe('all method', function () {
     it('returns all products', function () {
@@ -50,15 +59,83 @@ describe('create method', function () {
 });
 
 describe('delete method', function () {
-    // todo
+    it('soft deletes a product', function () {
+        $product = ProductModel::factory()->createOne();
+
+        $result = ProductFacade::delete($product->code);
+
+        expect($result)->toBeTrue()
+            ->and(ProductModel::withTrashed()->find($product->id)->trashed())->toBeTrue();
+    });
+
+    it('force deletes a product when second parameter is true', function () {
+        $product = ProductModel::factory()->createOne();
+
+        $result = ProductFacade::delete($product->code, true);
+
+        expect($result)->toBeTrue()
+            ->and(ProductModel::withTrashed()->find($product->id))->toBeNull();
+    });
+
+    it('throws an exception if SoftDeletes is not used by a model', function () {
+        $product = new class extends Model implements ProductInterface {};
+
+        ProductFacade::partialMock()
+            ->expects('find')
+            ->andReturn($product)
+            ->once();
+
+        ProductFacade::delete('code', true);
+    })->throws(MissingSoftDeletesException::class);
 });
 
 describe('find method', function () {
-    // todo
+    it('returns a product by code', function () {
+        $product = ProductModel::factory()->createOne();
+
+        $found = ProductFacade::find($product->code);
+
+        expect($found)->toBeInstanceOf(ProductModel::class)
+            ->and($found->code)->toBe($product->code);
+    });
+
+    it('returns trashed product when second parameter is true', function () {
+        $product = ProductModel::factory()->createOne();
+        $product->delete();
+
+        $found = ProductFacade::find($product->code, true);
+
+        expect($found)->not->toBeNull()
+            ->and($found->trashed())->toBeTrue();
+    });
+
+    it('throws an exception if SoftDeletes is not used by a model', function () {
+        bind(ProductInterface::class, function () {
+            return new class extends Model implements ProductInterface {};
+        });
+
+        ProductFacade::find('code', true);
+    })->throws(MissingSoftDeletesException::class);
 });
 
 describe('restore method', function () {
-    // todo
+    it('restores a trashed product', function () {
+        $product = ProductModel::factory()->createOne();
+        $product->delete();
+
+        $result = ProductFacade::restore($product->code);
+
+        expect($result)->toBeTrue()
+            ->and(ProductModel::find($product->id)->trashed())->toBeFalse();
+    });
+
+    it('throws an exception if SoftDeletes is not used by a model', function () {
+        bind(ProductInterface::class, function () {
+            return new class extends Model implements ProductInterface {};
+        });
+
+        ProductFacade::restore('code');
+    })->throws(MissingSoftDeletesException::class);
 });
 
 describe('trashed method', function () {
@@ -94,5 +171,30 @@ describe('update method', function () {
 });
 
 describe('updateOrCreate method', function () {
-    // todo
+    it('updates an existing product', function () {
+        $product = ProductModel::factory()->createOne([
+            'name' => ['en' => 'Old', 'pl' => 'Old'],
+        ]);
+
+        $updated = ProductFacade::updateOrCreate($product->code, [
+            'name' => ['en' => 'New', 'pl' => 'New'],
+        ]);
+
+        expect($updated->getTranslations('name')['en'])->toBe('New');
+    });
+
+    it('creates a new product when it does not exist', function () {
+        $blueprint = Blueprint::factory()->createOne();
+        $attributes = ProductModel::factory()->makeOne([
+            'blueprint_id' => $blueprint->id,
+        ]);
+
+        $created = Model::unguarded(fn () => ProductFacade::updateOrCreate($attributes->code, [
+            'blueprint_id' => $blueprint->id,
+            'name' => $attributes->getTranslations('name'),
+        ]));
+
+        expect($created->code)->toBe($attributes->code)
+            ->and(ProductModel::count())->toBe(1);
+    });
 });


### PR DESCRIPTION
## Summary
- alias missing `ProductFacadeInterface` for tests and bind facade contract
- test delete, find, restore and updateOrCreate methods of `Product` facade

## Testing
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_688e7ecbf1cc8320b889073b0bc96ed7