### PR TITLE
feat: add product sub-facades

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c494c21eaed0c93c8483ef3eb190dfa",
+    "content-hash": "b65da4d81672cbca82c0c27183605009",
     "packages": [
         {
             "name": "brick/math",
@@ -587,12 +587,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/gildsmith/contract.git",
-                "reference": "afdde439595b0fe807bbb0a740d49e3332fd1077"
+                "reference": "1c4777c17cfbc3e45472b3e2467408e1bc9278a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gildsmith/contract/zipball/afdde439595b0fe807bbb0a740d49e3332fd1077",
-                "reference": "afdde439595b0fe807bbb0a740d49e3332fd1077",
+                "url": "https://api.github.com/repos/gildsmith/contract/zipball/1c4777c17cfbc3e45472b3e2467408e1bc9278a3",
+                "reference": "1c4777c17cfbc3e45472b3e2467408e1bc9278a3",
                 "shasum": ""
             },
             "require-dev": {
@@ -620,7 +620,7 @@
                 "issues": "https://github.com/gildsmith/contract/issues",
                 "source": "https://github.com/gildsmith/contract/tree/master"
             },
-            "time": "2025-06-04T20:16:19+00:00"
+            "time": "2025-08-02T21:07:02+00:00"
         },
         {
             "name": "gildsmith/support",

--- a/src/Facades/AttributeFacade.php
+++ b/src/Facades/AttributeFacade.php
@@ -5,28 +5,24 @@ declare(strict_types=1);
 namespace Gildsmith\Product\Facades;
 
 use Gildsmith\Contract\Facades\Product\AttributeFacadeInterface;
-use Gildsmith\Contract\Facades\Product\AttributeValueFacadeInterface;
-use Gildsmith\Contract\Facades\Product\BlueprintFacadeInterface;
-use Gildsmith\Contract\Facades\Product\ProductCollectionFacadeInterface;
-use Gildsmith\Contract\Facades\ProductFacadeInterface;
-use Gildsmith\Contract\Product\ProductInterface;
+use Gildsmith\Contract\Product\AttributeInterface;
 use Gildsmith\Product\Exception\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 
-class ProductFacade implements ProductFacadeInterface
+class AttributeFacade implements AttributeFacadeInterface
 {
     /**
-     * @return Collection<int, Model&ProductInterface>
+     * @return Collection<int, Model&AttributeInterface>
      *
      * @throws MissingSoftDeletesException
      */
     public function all(bool $withTrashed = false): Collection
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeInterface::class);
 
         $withTrashed && $this->ensureSoftDeletes($builder);
 
@@ -35,10 +31,10 @@ class ProductFacade implements ProductFacadeInterface
             : $builder->get();
     }
 
-    public function create(array $data): ProductInterface
+    public function create(array $data): AttributeInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeInterface::class);
 
         return $builder::create($data);
     }
@@ -48,24 +44,24 @@ class ProductFacade implements ProductFacadeInterface
      */
     public function delete(string $code, bool $force = false): bool
     {
-        $product = $this->find($code);
+        $attribute = $this->find($code);
 
-        $force && $this->ensureSoftDeletes($product);
+        $force && $this->ensureSoftDeletes($attribute);
 
         return $force
-            ? (bool) $product->forceDelete()
-            : (bool) $product->delete();
+            ? (bool) $attribute->forceDelete()
+            : (bool) $attribute->delete();
     }
 
     /**
-     * @return (Model&ProductInterface)|null
+     * @return (Model&AttributeInterface)|null
      *
      * @throws MissingSoftDeletesException
      */
-    public function find(string $code, bool $withTrashed = false): ?ProductInterface
+    public function find(string $code, bool $withTrashed = false): ?AttributeInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeInterface::class);
 
         $withTrashed && $this->ensureSoftDeletes($builder);
 
@@ -88,14 +84,14 @@ class ProductFacade implements ProductFacadeInterface
     }
 
     /**
-     * @return Collection<int, Model&ProductInterface>
+     * @return Collection<int, Model&AttributeInterface>
      *
      * @throws MissingSoftDeletesException
      */
     public function trashed(): Collection
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeInterface::class);
 
         $this->ensureSoftDeletes($builder);
 
@@ -105,41 +101,21 @@ class ProductFacade implements ProductFacadeInterface
     /**
      * @throws MissingSoftDeletesException
      */
-    public function update(string $code, array $data): ProductInterface
+    public function update(string $code, array $data): AttributeInterface
     {
-        $product = $this->find($code, true);
+        $attribute = $this->find($code, true);
 
-        $product->update($data);
+        $attribute->update($data);
 
-        return $product->fresh();
+        return $attribute->fresh();
     }
 
-    public function updateOrCreate(string $code, array $data): ProductInterface
+    public function updateOrCreate(string $code, array $data): AttributeInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeInterface::class);
 
         return $builder::updateOrCreate(['code' => $code], $data);
-    }
-
-    public function attribute(): AttributeFacadeInterface
-    {
-        return resolve(AttributeFacadeInterface::class);
-    }
-
-    public function attributeValue(): AttributeValueFacadeInterface
-    {
-        return resolve(AttributeValueFacadeInterface::class);
-    }
-
-    public function blueprint(): BlueprintFacadeInterface
-    {
-        return resolve(BlueprintFacadeInterface::class);
-    }
-
-    public function collection(): ProductCollectionFacadeInterface
-    {
-        return resolve(ProductCollectionFacadeInterface::class);
     }
 
     /**

--- a/src/Facades/AttributeValueFacade.php
+++ b/src/Facades/AttributeValueFacade.php
@@ -4,29 +4,25 @@ declare(strict_types=1);
 
 namespace Gildsmith\Product\Facades;
 
-use Gildsmith\Contract\Facades\Product\AttributeFacadeInterface;
 use Gildsmith\Contract\Facades\Product\AttributeValueFacadeInterface;
-use Gildsmith\Contract\Facades\Product\BlueprintFacadeInterface;
-use Gildsmith\Contract\Facades\Product\ProductCollectionFacadeInterface;
-use Gildsmith\Contract\Facades\ProductFacadeInterface;
-use Gildsmith\Contract\Product\ProductInterface;
+use Gildsmith\Contract\Product\AttributeValueInterface;
 use Gildsmith\Product\Exception\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 
-class ProductFacade implements ProductFacadeInterface
+class AttributeValueFacade implements AttributeValueFacadeInterface
 {
     /**
-     * @return Collection<int, Model&ProductInterface>
+     * @return Collection<int, Model&AttributeValueInterface>
      *
      * @throws MissingSoftDeletesException
      */
     public function all(bool $withTrashed = false): Collection
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeValueInterface::class);
 
         $withTrashed && $this->ensureSoftDeletes($builder);
 
@@ -35,10 +31,10 @@ class ProductFacade implements ProductFacadeInterface
             : $builder->get();
     }
 
-    public function create(array $data): ProductInterface
+    public function create(array $data): AttributeValueInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeValueInterface::class);
 
         return $builder::create($data);
     }
@@ -48,24 +44,24 @@ class ProductFacade implements ProductFacadeInterface
      */
     public function delete(string $code, bool $force = false): bool
     {
-        $product = $this->find($code);
+        $attributeValue = $this->find($code);
 
-        $force && $this->ensureSoftDeletes($product);
+        $force && $this->ensureSoftDeletes($attributeValue);
 
         return $force
-            ? (bool) $product->forceDelete()
-            : (bool) $product->delete();
+            ? (bool) $attributeValue->forceDelete()
+            : (bool) $attributeValue->delete();
     }
 
     /**
-     * @return (Model&ProductInterface)|null
+     * @return (Model&AttributeValueInterface)|null
      *
      * @throws MissingSoftDeletesException
      */
-    public function find(string $code, bool $withTrashed = false): ?ProductInterface
+    public function find(string $code, bool $withTrashed = false): ?AttributeValueInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeValueInterface::class);
 
         $withTrashed && $this->ensureSoftDeletes($builder);
 
@@ -88,14 +84,14 @@ class ProductFacade implements ProductFacadeInterface
     }
 
     /**
-     * @return Collection<int, Model&ProductInterface>
+     * @return Collection<int, Model&AttributeValueInterface>
      *
      * @throws MissingSoftDeletesException
      */
     public function trashed(): Collection
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeValueInterface::class);
 
         $this->ensureSoftDeletes($builder);
 
@@ -105,41 +101,21 @@ class ProductFacade implements ProductFacadeInterface
     /**
      * @throws MissingSoftDeletesException
      */
-    public function update(string $code, array $data): ProductInterface
+    public function update(string $code, array $data): AttributeValueInterface
     {
-        $product = $this->find($code, true);
+        $attributeValue = $this->find($code, true);
 
-        $product->update($data);
+        $attributeValue->update($data);
 
-        return $product->fresh();
+        return $attributeValue->fresh();
     }
 
-    public function updateOrCreate(string $code, array $data): ProductInterface
+    public function updateOrCreate(string $code, array $data): AttributeValueInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(AttributeValueInterface::class);
 
         return $builder::updateOrCreate(['code' => $code], $data);
-    }
-
-    public function attribute(): AttributeFacadeInterface
-    {
-        return resolve(AttributeFacadeInterface::class);
-    }
-
-    public function attributeValue(): AttributeValueFacadeInterface
-    {
-        return resolve(AttributeValueFacadeInterface::class);
-    }
-
-    public function blueprint(): BlueprintFacadeInterface
-    {
-        return resolve(BlueprintFacadeInterface::class);
-    }
-
-    public function collection(): ProductCollectionFacadeInterface
-    {
-        return resolve(ProductCollectionFacadeInterface::class);
     }
 
     /**

--- a/src/Facades/BlueprintFacade.php
+++ b/src/Facades/BlueprintFacade.php
@@ -4,29 +4,25 @@ declare(strict_types=1);
 
 namespace Gildsmith\Product\Facades;
 
-use Gildsmith\Contract\Facades\Product\AttributeFacadeInterface;
-use Gildsmith\Contract\Facades\Product\AttributeValueFacadeInterface;
 use Gildsmith\Contract\Facades\Product\BlueprintFacadeInterface;
-use Gildsmith\Contract\Facades\Product\ProductCollectionFacadeInterface;
-use Gildsmith\Contract\Facades\ProductFacadeInterface;
-use Gildsmith\Contract\Product\ProductInterface;
+use Gildsmith\Contract\Product\BlueprintInterface;
 use Gildsmith\Product\Exception\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 
-class ProductFacade implements ProductFacadeInterface
+class BlueprintFacade implements BlueprintFacadeInterface
 {
     /**
-     * @return Collection<int, Model&ProductInterface>
+     * @return Collection<int, Model&BlueprintInterface>
      *
      * @throws MissingSoftDeletesException
      */
     public function all(bool $withTrashed = false): Collection
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(BlueprintInterface::class);
 
         $withTrashed && $this->ensureSoftDeletes($builder);
 
@@ -35,10 +31,10 @@ class ProductFacade implements ProductFacadeInterface
             : $builder->get();
     }
 
-    public function create(array $data): ProductInterface
+    public function create(array $data): BlueprintInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(BlueprintInterface::class);
 
         return $builder::create($data);
     }
@@ -48,24 +44,24 @@ class ProductFacade implements ProductFacadeInterface
      */
     public function delete(string $code, bool $force = false): bool
     {
-        $product = $this->find($code);
+        $blueprint = $this->find($code);
 
-        $force && $this->ensureSoftDeletes($product);
+        $force && $this->ensureSoftDeletes($blueprint);
 
         return $force
-            ? (bool) $product->forceDelete()
-            : (bool) $product->delete();
+            ? (bool) $blueprint->forceDelete()
+            : (bool) $blueprint->delete();
     }
 
     /**
-     * @return (Model&ProductInterface)|null
+     * @return (Model&BlueprintInterface)|null
      *
      * @throws MissingSoftDeletesException
      */
-    public function find(string $code, bool $withTrashed = false): ?ProductInterface
+    public function find(string $code, bool $withTrashed = false): ?BlueprintInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(BlueprintInterface::class);
 
         $withTrashed && $this->ensureSoftDeletes($builder);
 
@@ -88,14 +84,14 @@ class ProductFacade implements ProductFacadeInterface
     }
 
     /**
-     * @return Collection<int, Model&ProductInterface>
+     * @return Collection<int, Model&BlueprintInterface>
      *
      * @throws MissingSoftDeletesException
      */
     public function trashed(): Collection
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(BlueprintInterface::class);
 
         $this->ensureSoftDeletes($builder);
 
@@ -105,41 +101,21 @@ class ProductFacade implements ProductFacadeInterface
     /**
      * @throws MissingSoftDeletesException
      */
-    public function update(string $code, array $data): ProductInterface
+    public function update(string $code, array $data): BlueprintInterface
     {
-        $product = $this->find($code, true);
+        $blueprint = $this->find($code, true);
 
-        $product->update($data);
+        $blueprint->update($data);
 
-        return $product->fresh();
+        return $blueprint->fresh();
     }
 
-    public function updateOrCreate(string $code, array $data): ProductInterface
+    public function updateOrCreate(string $code, array $data): BlueprintInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(BlueprintInterface::class);
 
         return $builder::updateOrCreate(['code' => $code], $data);
-    }
-
-    public function attribute(): AttributeFacadeInterface
-    {
-        return resolve(AttributeFacadeInterface::class);
-    }
-
-    public function attributeValue(): AttributeValueFacadeInterface
-    {
-        return resolve(AttributeValueFacadeInterface::class);
-    }
-
-    public function blueprint(): BlueprintFacadeInterface
-    {
-        return resolve(BlueprintFacadeInterface::class);
-    }
-
-    public function collection(): ProductCollectionFacadeInterface
-    {
-        return resolve(ProductCollectionFacadeInterface::class);
     }
 
     /**

--- a/src/Facades/ProductCollectionFacade.php
+++ b/src/Facades/ProductCollectionFacade.php
@@ -4,29 +4,25 @@ declare(strict_types=1);
 
 namespace Gildsmith\Product\Facades;
 
-use Gildsmith\Contract\Facades\Product\AttributeFacadeInterface;
-use Gildsmith\Contract\Facades\Product\AttributeValueFacadeInterface;
-use Gildsmith\Contract\Facades\Product\BlueprintFacadeInterface;
 use Gildsmith\Contract\Facades\Product\ProductCollectionFacadeInterface;
-use Gildsmith\Contract\Facades\ProductFacadeInterface;
-use Gildsmith\Contract\Product\ProductInterface;
+use Gildsmith\Contract\Product\ProductCollectionInterface;
 use Gildsmith\Product\Exception\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 
-class ProductFacade implements ProductFacadeInterface
+class ProductCollectionFacade implements ProductCollectionFacadeInterface
 {
     /**
-     * @return Collection<int, Model&ProductInterface>
+     * @return Collection<int, Model&ProductCollectionInterface>
      *
      * @throws MissingSoftDeletesException
      */
     public function all(bool $withTrashed = false): Collection
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(ProductCollectionInterface::class);
 
         $withTrashed && $this->ensureSoftDeletes($builder);
 
@@ -35,10 +31,10 @@ class ProductFacade implements ProductFacadeInterface
             : $builder->get();
     }
 
-    public function create(array $data): ProductInterface
+    public function create(array $data): ProductCollectionInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(ProductCollectionInterface::class);
 
         return $builder::create($data);
     }
@@ -48,24 +44,24 @@ class ProductFacade implements ProductFacadeInterface
      */
     public function delete(string $code, bool $force = false): bool
     {
-        $product = $this->find($code);
+        $productCollection = $this->find($code);
 
-        $force && $this->ensureSoftDeletes($product);
+        $force && $this->ensureSoftDeletes($productCollection);
 
         return $force
-            ? (bool) $product->forceDelete()
-            : (bool) $product->delete();
+            ? (bool) $productCollection->forceDelete()
+            : (bool) $productCollection->delete();
     }
 
     /**
-     * @return (Model&ProductInterface)|null
+     * @return (Model&ProductCollectionInterface)|null
      *
      * @throws MissingSoftDeletesException
      */
-    public function find(string $code, bool $withTrashed = false): ?ProductInterface
+    public function find(string $code, bool $withTrashed = false): ?ProductCollectionInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(ProductCollectionInterface::class);
 
         $withTrashed && $this->ensureSoftDeletes($builder);
 
@@ -88,14 +84,14 @@ class ProductFacade implements ProductFacadeInterface
     }
 
     /**
-     * @return Collection<int, Model&ProductInterface>
+     * @return Collection<int, Model&ProductCollectionInterface>
      *
      * @throws MissingSoftDeletesException
      */
     public function trashed(): Collection
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(ProductCollectionInterface::class);
 
         $this->ensureSoftDeletes($builder);
 
@@ -105,41 +101,21 @@ class ProductFacade implements ProductFacadeInterface
     /**
      * @throws MissingSoftDeletesException
      */
-    public function update(string $code, array $data): ProductInterface
+    public function update(string $code, array $data): ProductCollectionInterface
     {
-        $product = $this->find($code, true);
+        $productCollection = $this->find($code, true);
 
-        $product->update($data);
+        $productCollection->update($data);
 
-        return $product->fresh();
+        return $productCollection->fresh();
     }
 
-    public function updateOrCreate(string $code, array $data): ProductInterface
+    public function updateOrCreate(string $code, array $data): ProductCollectionInterface
     {
         /** @var Builder $builder */
-        $builder = resolve(ProductInterface::class);
+        $builder = resolve(ProductCollectionInterface::class);
 
         return $builder::updateOrCreate(['code' => $code], $data);
-    }
-
-    public function attribute(): AttributeFacadeInterface
-    {
-        return resolve(AttributeFacadeInterface::class);
-    }
-
-    public function attributeValue(): AttributeValueFacadeInterface
-    {
-        return resolve(AttributeValueFacadeInterface::class);
-    }
-
-    public function blueprint(): BlueprintFacadeInterface
-    {
-        return resolve(BlueprintFacadeInterface::class);
-    }
-
-    public function collection(): ProductCollectionFacadeInterface
-    {
-        return resolve(ProductCollectionFacadeInterface::class);
     }
 
     /**

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 namespace Gildsmith\Product\Providers;
 
+use Gildsmith\Contract\Facades\Product\AttributeFacadeInterface;
+use Gildsmith\Contract\Facades\Product\AttributeValueFacadeInterface;
+use Gildsmith\Contract\Facades\Product\BlueprintFacadeInterface;
+use Gildsmith\Contract\Facades\Product\ProductCollectionFacadeInterface;
 use Gildsmith\Contract\Facades\ProductFacadeInterface;
 use Gildsmith\Contract\Product\AttributeInterface;
 use Gildsmith\Contract\Product\AttributeValueInterface;
 use Gildsmith\Contract\Product\BlueprintInterface;
 use Gildsmith\Contract\Product\ProductCollectionInterface;
 use Gildsmith\Contract\Product\ProductInterface;
+use Gildsmith\Product\Facades\AttributeFacade;
+use Gildsmith\Product\Facades\AttributeValueFacade;
+use Gildsmith\Product\Facades\BlueprintFacade;
+use Gildsmith\Product\Facades\ProductCollectionFacade;
 use Gildsmith\Product\Facades\ProductFacade;
 use Gildsmith\Product\Models\Attribute;
 use Gildsmith\Product\Models\AttributeValue;
@@ -22,8 +30,18 @@ final class AppServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        // Facade
+        // Ensure backwards compatibility with older facade accessor
+        if (! interface_exists('\\Gildsmith\\Contract\\Facades\\Product')) {
+            class_alias(ProductFacadeInterface::class, '\\Gildsmith\\Contract\\Facades\\Product');
+        }
+
+        // Facades
         $this->app->bind(ProductFacadeInterface::class, fn () => new ProductFacade);
+        $this->app->bind('Gildsmith\\Contract\\Facades\\Product', fn () => new ProductFacade);
+        $this->app->bind(AttributeFacadeInterface::class, fn () => new AttributeFacade);
+        $this->app->bind(AttributeValueFacadeInterface::class, fn () => new AttributeValueFacade);
+        $this->app->bind(BlueprintFacadeInterface::class, fn () => new BlueprintFacade);
+        $this->app->bind(ProductCollectionFacadeInterface::class, fn () => new ProductCollectionFacade);
 
         // Models
         $this->app->bind(AttributeValueInterface::class, AttributeValue::class);


### PR DESCRIPTION
## Summary
- implement dedicated facades for attributes, attribute values, blueprints and collections
- extend `ProductFacade` to expose sub-facades
- bind new facades in service provider with backward compatibility alias

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688e7f3d12348320820c2e5a7bac39e4