### PR TITLE
Rename Exception namespace for PSR-4 compliance

### DIFF
--- a/src/Exceptions/MissingSoftDeletesException.php
+++ b/src/Exceptions/MissingSoftDeletesException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Gildsmith\Product\Exception;
+namespace Gildsmith\Product\Exceptions;
 
 use Exception;
 

--- a/src/Facades/AttributeFacade.php
+++ b/src/Facades/AttributeFacade.php
@@ -6,7 +6,7 @@ namespace Gildsmith\Product\Facades;
 
 use Gildsmith\Contract\Facades\Product\AttributeFacadeInterface;
 use Gildsmith\Contract\Product\AttributeInterface;
-use Gildsmith\Product\Exception\MissingSoftDeletesException;
+use Gildsmith\Product\Exceptions\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/src/Facades/AttributeValueFacade.php
+++ b/src/Facades/AttributeValueFacade.php
@@ -6,7 +6,7 @@ namespace Gildsmith\Product\Facades;
 
 use Gildsmith\Contract\Facades\Product\AttributeValueFacadeInterface;
 use Gildsmith\Contract\Product\AttributeValueInterface;
-use Gildsmith\Product\Exception\MissingSoftDeletesException;
+use Gildsmith\Product\Exceptions\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/src/Facades/BlueprintFacade.php
+++ b/src/Facades/BlueprintFacade.php
@@ -6,7 +6,7 @@ namespace Gildsmith\Product\Facades;
 
 use Gildsmith\Contract\Facades\Product\BlueprintFacadeInterface;
 use Gildsmith\Contract\Product\BlueprintInterface;
-use Gildsmith\Product\Exception\MissingSoftDeletesException;
+use Gildsmith\Product\Exceptions\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/src/Facades/ProductCollectionFacade.php
+++ b/src/Facades/ProductCollectionFacade.php
@@ -6,7 +6,7 @@ namespace Gildsmith\Product\Facades;
 
 use Gildsmith\Contract\Facades\Product\ProductCollectionFacadeInterface;
 use Gildsmith\Contract\Product\ProductCollectionInterface;
-use Gildsmith\Product\Exception\MissingSoftDeletesException;
+use Gildsmith\Product\Exceptions\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/src/Facades/ProductFacade.php
+++ b/src/Facades/ProductFacade.php
@@ -10,7 +10,7 @@ use Gildsmith\Contract\Facades\Product\BlueprintFacadeInterface;
 use Gildsmith\Contract\Facades\Product\ProductCollectionFacadeInterface;
 use Gildsmith\Contract\Facades\ProductFacadeInterface;
 use Gildsmith\Contract\Product\ProductInterface;
-use Gildsmith\Product\Exception\MissingSoftDeletesException;
+use Gildsmith\Product\Exceptions\MissingSoftDeletesException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/tests/Unit/Facades/Product.test.php
+++ b/tests/Unit/Facades/Product.test.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Gildsmith\Contract\Product\ProductInterface;
-use Gildsmith\Product\Exception\MissingSoftDeletesException;
+use Gildsmith\Product\Exceptions\MissingSoftDeletesException;
 use Gildsmith\Product\Facades\ProductFacade as ProductFacadeConcrete;
 use Gildsmith\Product\Models\Blueprint;
 use Gildsmith\Product\Models\Product as ProductModel;


### PR DESCRIPTION
## Summary
- rename `Exception` directory to `Exceptions`
- update exception namespace imports across facades and tests

## Testing
- `vendor/bin/pint`
- `vendor/bin/phpstan analyse src`
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_689558d4a5f08320aa29236cd337fa8c