### PR TITLE
Add controllers and tests for blueprints and product collections

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,11 @@ use Gildsmith\Product\Controllers\AttributeValue\AttributeValueDeleteController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueFindController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueIndexController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueUpdateController;
+use Gildsmith\Product\Controllers\Blueprint\BlueprintCreateController;
+use Gildsmith\Product\Controllers\Blueprint\BlueprintDeleteController;
+use Gildsmith\Product\Controllers\Blueprint\BlueprintFindController;
+use Gildsmith\Product\Controllers\Blueprint\BlueprintIndexController;
+use Gildsmith\Product\Controllers\Blueprint\BlueprintUpdateController;
 use Gildsmith\Product\Controllers\Product\ProductCreateController;
 use Gildsmith\Product\Controllers\Product\ProductDeleteController;
 use Gildsmith\Product\Controllers\Product\ProductFindController;
@@ -19,6 +24,11 @@ use Gildsmith\Product\Controllers\Product\ProductIndexController;
 use Gildsmith\Product\Controllers\Product\ProductRestoreController;
 use Gildsmith\Product\Controllers\Product\ProductTrashedController;
 use Gildsmith\Product\Controllers\Product\ProductUpdateController;
+use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionCreateController;
+use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionDeleteController;
+use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionFindController;
+use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionIndexController;
+use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionUpdateController;
 
 Route::prefix('products')->group(function () {
     Route::get('/', ProductIndexController::class);
@@ -47,4 +57,22 @@ Route::prefix('attributes')->group(function () {
         Route::patch('/{value}', AttributeValueUpdateController::class);
         Route::delete('/{value}', AttributeValueDeleteController::class);
     });
+});
+
+Route::prefix('blueprints')->group(function () {
+    Route::get('/', BlueprintIndexController::class);
+    Route::post('/', BlueprintCreateController::class);
+    Route::get('/{code}', BlueprintFindController::class);
+    Route::put('/{code}', BlueprintUpdateController::class);
+    Route::patch('/{code}', BlueprintUpdateController::class);
+    Route::delete('/{code}', BlueprintDeleteController::class);
+});
+
+Route::prefix('collections')->group(function () {
+    Route::get('/', ProductCollectionIndexController::class);
+    Route::post('/', ProductCollectionCreateController::class);
+    Route::get('/{code}', ProductCollectionFindController::class);
+    Route::put('/{code}', ProductCollectionUpdateController::class);
+    Route::patch('/{code}', ProductCollectionUpdateController::class);
+    Route::delete('/{code}', ProductCollectionDeleteController::class);
 });

--- a/src/Controllers/Blueprint/BlueprintCreateController.php
+++ b/src/Controllers/Blueprint/BlueprintCreateController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Blueprint;
+
+use Gildsmith\Contract\Product\BlueprintInterface;
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class BlueprintCreateController extends Controller
+{
+    public function __invoke(Request $request): BlueprintInterface
+    {
+        return Model::unguarded(fn () => Product::blueprint()->create($request->all()));
+    }
+}

--- a/src/Controllers/Blueprint/BlueprintDeleteController.php
+++ b/src/Controllers/Blueprint/BlueprintDeleteController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Blueprint;
+
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+
+class BlueprintDeleteController extends Controller
+{
+    public function __invoke(string $code): bool
+    {
+        return Product::blueprint()->delete($code);
+    }
+}

--- a/src/Controllers/Blueprint/BlueprintFindController.php
+++ b/src/Controllers/Blueprint/BlueprintFindController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Blueprint;
+
+use Gildsmith\Contract\Product\BlueprintInterface;
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+
+class BlueprintFindController extends Controller
+{
+    public function __invoke(string $code): ?BlueprintInterface
+    {
+        return Product::blueprint()->find($code);
+    }
+}

--- a/src/Controllers/Blueprint/BlueprintIndexController.php
+++ b/src/Controllers/Blueprint/BlueprintIndexController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Blueprint;
+
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+
+class BlueprintIndexController extends Controller
+{
+    public function __invoke(): Collection
+    {
+        return Product::blueprint()->all();
+    }
+}

--- a/src/Controllers/Blueprint/BlueprintUpdateController.php
+++ b/src/Controllers/Blueprint/BlueprintUpdateController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Blueprint;
+
+use Gildsmith\Contract\Product\BlueprintInterface;
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class BlueprintUpdateController extends Controller
+{
+    public function __invoke(Request $request, string $code): BlueprintInterface
+    {
+        return Product::blueprint()->updateOrCreate($code, $request->except('code'));
+    }
+}

--- a/src/Controllers/ProductCollection/ProductCollectionCreateController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionCreateController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\ProductCollection;
+
+use Gildsmith\Contract\Product\ProductCollectionInterface;
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class ProductCollectionCreateController extends Controller
+{
+    public function __invoke(Request $request): ProductCollectionInterface
+    {
+        return Model::unguarded(fn () => Product::collection()->create($request->all()));
+    }
+}

--- a/src/Controllers/ProductCollection/ProductCollectionDeleteController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionDeleteController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\ProductCollection;
+
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+
+class ProductCollectionDeleteController extends Controller
+{
+    public function __invoke(string $code): bool
+    {
+        return Product::collection()->delete($code);
+    }
+}

--- a/src/Controllers/ProductCollection/ProductCollectionFindController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionFindController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\ProductCollection;
+
+use Gildsmith\Contract\Product\ProductCollectionInterface;
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+
+class ProductCollectionFindController extends Controller
+{
+    public function __invoke(string $code): ?ProductCollectionInterface
+    {
+        return Product::collection()->find($code);
+    }
+}

--- a/src/Controllers/ProductCollection/ProductCollectionIndexController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionIndexController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\ProductCollection;
+
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+
+class ProductCollectionIndexController extends Controller
+{
+    public function __invoke(): Collection
+    {
+        return Product::collection()->all();
+    }
+}

--- a/src/Controllers/ProductCollection/ProductCollectionUpdateController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionUpdateController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\ProductCollection;
+
+use Gildsmith\Contract\Product\ProductCollectionInterface;
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class ProductCollectionUpdateController extends Controller
+{
+    public function __invoke(Request $request, string $code): ProductCollectionInterface
+    {
+        return Product::collection()->updateOrCreate($code, $request->except('code'));
+    }
+}

--- a/tests/Feature/BlueprintController.test.php
+++ b/tests/Feature/BlueprintController.test.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Gildsmith\Product\Models\Blueprint;
+
+it('lists blueprints', function () {
+    Blueprint::factory()->count(3)->create();
+
+    $response = $this->getJson('/blueprints');
+
+    $response->assertOk()->assertJsonCount(3);
+});
+
+it('creates a blueprint', function () {
+    $payload = [
+        'code' => 'test_blueprint',
+        'name' => ['en' => 'Test', 'pl' => 'Test'],
+    ];
+
+    $response = $this->postJson('/blueprints', $payload);
+
+    $response->assertCreated()->assertJsonPath('code', 'test_blueprint');
+    $this->assertDatabaseHas('blueprints', ['code' => 'test_blueprint']);
+});
+
+it('shows a blueprint', function () {
+    $blueprint = Blueprint::factory()->create();
+
+    $response = $this->getJson("/blueprints/{$blueprint->code}");
+
+    $response->assertOk()->assertJsonPath('code', $blueprint->code);
+});
+
+it('updates a blueprint', function () {
+    $blueprint = Blueprint::factory()->create();
+
+    $response = $this->putJson("/blueprints/{$blueprint->code}", [
+        'name' => ['en' => 'Updated', 'pl' => 'Zaktualizowany'],
+    ]);
+
+    $response->assertOk()->assertJsonPath('name.en', 'Updated');
+    $this->assertDatabaseHas('blueprints', ['code' => $blueprint->code, 'name->en' => 'Updated']);
+});
+
+it('deletes a blueprint', function () {
+    $blueprint = Blueprint::factory()->create();
+
+    $response = $this->deleteJson("/blueprints/{$blueprint->code}");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertDatabaseMissing('blueprints', ['code' => $blueprint->code]);
+});

--- a/tests/Feature/ProductCollectionController.test.php
+++ b/tests/Feature/ProductCollectionController.test.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Gildsmith\Product\Models\ProductCollection;
+
+it('lists product collections', function () {
+    ProductCollection::factory()->count(3)->create();
+
+    $response = $this->getJson('/collections');
+
+    $response->assertOk()->assertJsonCount(3);
+});
+
+it('creates a product collection', function () {
+    $payload = [
+        'code' => 'summer',
+        'type' => 'season',
+        'name' => ['en' => 'Summer', 'pl' => 'Lato'],
+    ];
+
+    $response = $this->postJson('/collections', $payload);
+
+    $response->assertCreated()->assertJsonPath('code', 'summer');
+    $this->assertDatabaseHas('product_collections', ['code' => 'summer']);
+});
+
+it('shows a product collection', function () {
+    $collection = ProductCollection::factory()->create();
+
+    $response = $this->getJson("/collections/{$collection->code}");
+
+    $response->assertOk()->assertJsonPath('code', $collection->code);
+});
+
+it('updates a product collection', function () {
+    $collection = ProductCollection::factory()->create();
+
+    $response = $this->putJson("/collections/{$collection->code}", [
+        'name' => ['en' => 'Updated', 'pl' => 'Zaktualizowany'],
+    ]);
+
+    $response->assertOk()->assertJsonPath('name.en', 'Updated');
+    $this->assertDatabaseHas('product_collections', ['code' => $collection->code, 'name->en' => 'Updated']);
+});
+
+it('deletes a product collection', function () {
+    $collection = ProductCollection::factory()->create();
+
+    $response = $this->deleteJson("/collections/{$collection->code}");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertDatabaseMissing('product_collections', ['code' => $collection->code]);
+});


### PR DESCRIPTION
## Summary
- add CRUD controllers for blueprints and product collections
- expose new blueprint and collection routes
- cover endpoints with feature tests

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68955b5e65a88320bc0acfad09f25f40