### PR TITLE
Return 404 when records are missing

### DIFF
--- a/src/Controllers/Attribute/AttributeFindController.php
+++ b/src/Controllers/Attribute/AttributeFindController.php
@@ -6,12 +6,17 @@ namespace Gildsmith\Product\Controllers\Attribute;
 
 use Gildsmith\Contract\Product\AttributeInterface;
 use Gildsmith\Support\Facades\Product;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 
 class AttributeFindController extends Controller
 {
-    public function __invoke(string $code): ?AttributeInterface
+    public function __invoke(string $code): AttributeInterface
     {
-        return Product::attribute()->find($code);
+        $attribute = Product::attribute()->find($code);
+
+        abort_if(! $attribute, Response::HTTP_NOT_FOUND);
+
+        return $attribute;
     }
 }

--- a/src/Controllers/AttributeValue/AttributeValueFindController.php
+++ b/src/Controllers/AttributeValue/AttributeValueFindController.php
@@ -6,14 +6,21 @@ namespace Gildsmith\Product\Controllers\AttributeValue;
 
 use Gildsmith\Contract\Product\AttributeValueInterface;
 use Gildsmith\Support\Facades\Product;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 
 class AttributeValueFindController extends Controller
 {
-    public function __invoke(string $attribute, string $value): ?AttributeValueInterface
+    public function __invoke(string $attribute, string $value): AttributeValueInterface
     {
         $attributeModel = Product::attribute()->find($attribute);
 
-        return $attributeModel->values()->where('code', $value)->first();
+        abort_if(! $attributeModel, Response::HTTP_NOT_FOUND);
+
+        $valueModel = $attributeModel->values()->where('code', $value)->first();
+
+        abort_if(! $valueModel, Response::HTTP_NOT_FOUND);
+
+        return $valueModel;
     }
 }

--- a/src/Controllers/Product/ProductFindController.php
+++ b/src/Controllers/Product/ProductFindController.php
@@ -6,15 +6,20 @@ namespace Gildsmith\Product\Controllers\Product;
 
 use Gildsmith\Contract\Product\ProductInterface;
 use Gildsmith\Support\Facades\Product;
+use Illuminate\Http\Response;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
 class ProductFindController extends Controller
 {
-    public function __invoke(Request $request, string $code): ?ProductInterface
+    public function __invoke(Request $request, string $code): ProductInterface
     {
         $withTrashed = $request->boolean('withTrashed');
 
-        return Product::find($code, $withTrashed);
+        $product = Product::find($code, $withTrashed);
+
+        abort_if(! $product, Response::HTTP_NOT_FOUND);
+
+        return $product;
     }
 }

--- a/tests/Feature/AttributeController.test.php
+++ b/tests/Feature/AttributeController.test.php
@@ -32,6 +32,12 @@ it('shows an attribute', function () {
     $response->assertOk()->assertJsonPath('code', $attribute->code);
 });
 
+it('returns 404 when attribute is missing', function () {
+    $response = $this->getJson('/attributes/missing');
+
+    $response->assertNotFound();
+});
+
 it('updates an attribute', function () {
     $attribute = Attribute::factory()->create();
 

--- a/tests/Feature/AttributeValueController.test.php
+++ b/tests/Feature/AttributeValueController.test.php
@@ -36,6 +36,20 @@ it('shows an attribute value', function () {
     $response->assertOk()->assertJsonPath('code', $value->code);
 });
 
+it('returns 404 when attribute is missing', function () {
+    $response = $this->getJson('/attributes/missing/values/any');
+
+    $response->assertNotFound();
+});
+
+it('returns 404 when attribute value is missing', function () {
+    $attribute = Attribute::factory()->create();
+
+    $response = $this->getJson("/attributes/{$attribute->code}/values/missing");
+
+    $response->assertNotFound();
+});
+
 it('updates an attribute value', function () {
     $value = AttributeValue::factory()->for(Attribute::factory())->create();
 

--- a/tests/Feature/ProductController.test.php
+++ b/tests/Feature/ProductController.test.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Gildsmith\Product\Models\Product;
+
+it('shows a product', function () {
+    $product = Product::factory()->create();
+
+    $response = $this->getJson("/products/{$product->code}");
+
+    $response->assertOk()->assertJsonPath('code', $product->code);
+});
+
+it('returns 404 when product is missing', function () {
+    $response = $this->getJson('/products/missing');
+
+    $response->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- abort with 404 in product, attribute, and attribute value lookup controllers
- add feature coverage for 404 responses on missing records

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68955b71edb48320910dc478522107d4