### PR TITLE
Add trash/restore endpoints and force deletes for soft-deletable models

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -6,44 +6,61 @@ use Gildsmith\Product\Controllers\Attribute\AttributeCreateController;
 use Gildsmith\Product\Controllers\Attribute\AttributeDeleteController;
 use Gildsmith\Product\Controllers\Attribute\AttributeFindController;
 use Gildsmith\Product\Controllers\Attribute\AttributeIndexController;
+use Gildsmith\Product\Controllers\Attribute\AttributeRestoreController;
+use Gildsmith\Product\Controllers\Attribute\AttributeTrashController;
+use Gildsmith\Product\Controllers\Attribute\AttributeTrashedController;
 use Gildsmith\Product\Controllers\Attribute\AttributeUpdateController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueCreateController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueDeleteController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueFindController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueIndexController;
+use Gildsmith\Product\Controllers\AttributeValue\AttributeValueRestoreController;
+use Gildsmith\Product\Controllers\AttributeValue\AttributeValueTrashController;
+use Gildsmith\Product\Controllers\AttributeValue\AttributeValueTrashedController;
 use Gildsmith\Product\Controllers\AttributeValue\AttributeValueUpdateController;
 use Gildsmith\Product\Controllers\Blueprint\BlueprintCreateController;
 use Gildsmith\Product\Controllers\Blueprint\BlueprintDeleteController;
 use Gildsmith\Product\Controllers\Blueprint\BlueprintFindController;
 use Gildsmith\Product\Controllers\Blueprint\BlueprintIndexController;
+use Gildsmith\Product\Controllers\Blueprint\BlueprintRestoreController;
+use Gildsmith\Product\Controllers\Blueprint\BlueprintTrashController;
+use Gildsmith\Product\Controllers\Blueprint\BlueprintTrashedController;
 use Gildsmith\Product\Controllers\Blueprint\BlueprintUpdateController;
 use Gildsmith\Product\Controllers\Product\ProductCreateController;
 use Gildsmith\Product\Controllers\Product\ProductDeleteController;
 use Gildsmith\Product\Controllers\Product\ProductFindController;
 use Gildsmith\Product\Controllers\Product\ProductIndexController;
 use Gildsmith\Product\Controllers\Product\ProductRestoreController;
+use Gildsmith\Product\Controllers\Product\ProductTrashController;
 use Gildsmith\Product\Controllers\Product\ProductTrashedController;
 use Gildsmith\Product\Controllers\Product\ProductUpdateController;
 use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionCreateController;
 use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionDeleteController;
 use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionFindController;
 use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionIndexController;
+use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionRestoreController;
+use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionTrashController;
+use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionTrashedController;
 use Gildsmith\Product\Controllers\ProductCollection\ProductCollectionUpdateController;
 
 Route::prefix('products')->group(function () {
     Route::get('/', ProductIndexController::class);
     Route::post('/', ProductCreateController::class);
     Route::get('/trashed', ProductTrashedController::class);
+    Route::post('/{code}/trash', ProductTrashController::class);
+    Route::post('/{code}/restore', ProductRestoreController::class);
     Route::get('/{code}', ProductFindController::class);
     Route::put('/{code}', ProductUpdateController::class);
     Route::patch('/{code}', ProductUpdateController::class);
     Route::delete('/{code}', ProductDeleteController::class);
-    Route::post('/{code}/restore', ProductRestoreController::class);
 });
 
 Route::prefix('attributes')->group(function () {
     Route::get('/', AttributeIndexController::class);
     Route::post('/', AttributeCreateController::class);
+    Route::get('/trashed', AttributeTrashedController::class);
+    Route::post('/{attribute}/trash', AttributeTrashController::class);
+    Route::post('/{attribute}/restore', AttributeRestoreController::class);
     Route::get('/{attribute}', AttributeFindController::class);
     Route::put('/{attribute}', AttributeUpdateController::class);
     Route::patch('/{attribute}', AttributeUpdateController::class);
@@ -52,6 +69,9 @@ Route::prefix('attributes')->group(function () {
     Route::prefix('{attribute}/values')->group(function () {
         Route::get('/', AttributeValueIndexController::class);
         Route::post('/', AttributeValueCreateController::class);
+        Route::get('/trashed', AttributeValueTrashedController::class);
+        Route::post('/{value}/trash', AttributeValueTrashController::class);
+        Route::post('/{value}/restore', AttributeValueRestoreController::class);
         Route::get('/{value}', AttributeValueFindController::class);
         Route::put('/{value}', AttributeValueUpdateController::class);
         Route::patch('/{value}', AttributeValueUpdateController::class);
@@ -62,6 +82,9 @@ Route::prefix('attributes')->group(function () {
 Route::prefix('blueprints')->group(function () {
     Route::get('/', BlueprintIndexController::class);
     Route::post('/', BlueprintCreateController::class);
+    Route::get('/trashed', BlueprintTrashedController::class);
+    Route::post('/{code}/trash', BlueprintTrashController::class);
+    Route::post('/{code}/restore', BlueprintRestoreController::class);
     Route::get('/{code}', BlueprintFindController::class);
     Route::put('/{code}', BlueprintUpdateController::class);
     Route::patch('/{code}', BlueprintUpdateController::class);
@@ -71,6 +94,9 @@ Route::prefix('blueprints')->group(function () {
 Route::prefix('collections')->group(function () {
     Route::get('/', ProductCollectionIndexController::class);
     Route::post('/', ProductCollectionCreateController::class);
+    Route::get('/trashed', ProductCollectionTrashedController::class);
+    Route::post('/{code}/trash', ProductCollectionTrashController::class);
+    Route::post('/{code}/restore', ProductCollectionRestoreController::class);
     Route::get('/{code}', ProductCollectionFindController::class);
     Route::put('/{code}', ProductCollectionUpdateController::class);
     Route::patch('/{code}', ProductCollectionUpdateController::class);

--- a/src/Controllers/Attribute/AttributeDeleteController.php
+++ b/src/Controllers/Attribute/AttributeDeleteController.php
@@ -11,6 +11,6 @@ class AttributeDeleteController extends Controller
 {
     public function __invoke(string $code): bool
     {
-        return Product::attribute()->delete($code);
+        return Product::attribute()->delete($code, true);
     }
 }

--- a/src/Controllers/Attribute/AttributeRestoreController.php
+++ b/src/Controllers/Attribute/AttributeRestoreController.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Gildsmith\Product\Controllers\Product;
+namespace Gildsmith\Product\Controllers\Attribute;
 
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class ProductDeleteController extends Controller
+class AttributeRestoreController extends Controller
 {
     public function __invoke(string $code): bool
     {
-        return Product::delete($code, true);
+        return Product::attribute()->restore($code);
     }
 }

--- a/src/Controllers/Attribute/AttributeTrashController.php
+++ b/src/Controllers/Attribute/AttributeTrashController.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Gildsmith\Product\Controllers\Product;
+namespace Gildsmith\Product\Controllers\Attribute;
 
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class ProductDeleteController extends Controller
+class AttributeTrashController extends Controller
 {
     public function __invoke(string $code): bool
     {
-        return Product::delete($code, true);
+        return Product::attribute()->delete($code);
     }
 }

--- a/src/Controllers/Attribute/AttributeTrashedController.php
+++ b/src/Controllers/Attribute/AttributeTrashedController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Attribute;
+
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+
+class AttributeTrashedController extends Controller
+{
+    public function __invoke(): Collection
+    {
+        return Product::attribute()->trashed();
+    }
+}

--- a/src/Controllers/AttributeValue/AttributeValueRestoreController.php
+++ b/src/Controllers/AttributeValue/AttributeValueRestoreController.php
@@ -8,7 +8,7 @@ use Gildsmith\Contract\Product\AttributeValueInterface;
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class AttributeValueDeleteController extends Controller
+class AttributeValueRestoreController extends Controller
 {
     public function __invoke(string $attribute, string $value): bool
     {
@@ -17,6 +17,6 @@ class AttributeValueDeleteController extends Controller
         /** @var AttributeValueInterface $valueModel */
         $valueModel = $attributeModel->values()->withTrashed()->where('code', $value)->firstOrFail();
 
-        return (bool) $valueModel->forceDelete();
+        return (bool) $valueModel->restore();
     }
 }

--- a/src/Controllers/AttributeValue/AttributeValueTrashController.php
+++ b/src/Controllers/AttributeValue/AttributeValueTrashController.php
@@ -8,15 +8,15 @@ use Gildsmith\Contract\Product\AttributeValueInterface;
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class AttributeValueDeleteController extends Controller
+class AttributeValueTrashController extends Controller
 {
     public function __invoke(string $attribute, string $value): bool
     {
         $attributeModel = Product::attribute()->find($attribute);
 
         /** @var AttributeValueInterface $valueModel */
-        $valueModel = $attributeModel->values()->withTrashed()->where('code', $value)->firstOrFail();
+        $valueModel = $attributeModel->values()->where('code', $value)->firstOrFail();
 
-        return (bool) $valueModel->forceDelete();
+        return (bool) $valueModel->delete();
     }
 }

--- a/src/Controllers/AttributeValue/AttributeValueTrashedController.php
+++ b/src/Controllers/AttributeValue/AttributeValueTrashedController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\AttributeValue;
+
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+
+class AttributeValueTrashedController extends Controller
+{
+    public function __invoke(string $attribute): Collection
+    {
+        $attributeModel = Product::attribute()->find($attribute);
+
+        return $attributeModel->values()->onlyTrashed()->get();
+    }
+}

--- a/src/Controllers/Blueprint/BlueprintRestoreController.php
+++ b/src/Controllers/Blueprint/BlueprintRestoreController.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Gildsmith\Product\Controllers\Product;
+namespace Gildsmith\Product\Controllers\Blueprint;
 
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class ProductDeleteController extends Controller
+class BlueprintRestoreController extends Controller
 {
     public function __invoke(string $code): bool
     {
-        return Product::delete($code, true);
+        return Product::blueprint()->restore($code);
     }
 }

--- a/src/Controllers/Blueprint/BlueprintTrashController.php
+++ b/src/Controllers/Blueprint/BlueprintTrashController.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Gildsmith\Product\Controllers\Product;
+namespace Gildsmith\Product\Controllers\Blueprint;
 
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class ProductDeleteController extends Controller
+class BlueprintTrashController extends Controller
 {
     public function __invoke(string $code): bool
     {
-        return Product::delete($code, true);
+        return Product::blueprint()->delete($code);
     }
 }

--- a/src/Controllers/Blueprint/BlueprintTrashedController.php
+++ b/src/Controllers/Blueprint/BlueprintTrashedController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\Blueprint;
+
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+
+class BlueprintTrashedController extends Controller
+{
+    public function __invoke(): Collection
+    {
+        return Product::blueprint()->trashed();
+    }
+}

--- a/src/Controllers/Product/ProductTrashController.php
+++ b/src/Controllers/Product/ProductTrashController.php
@@ -7,10 +7,10 @@ namespace Gildsmith\Product\Controllers\Product;
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class ProductDeleteController extends Controller
+class ProductTrashController extends Controller
 {
     public function __invoke(string $code): bool
     {
-        return Product::delete($code, true);
+        return Product::delete($code);
     }
 }

--- a/src/Controllers/ProductCollection/ProductCollectionRestoreController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionRestoreController.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Gildsmith\Product\Controllers\Product;
+namespace Gildsmith\Product\Controllers\ProductCollection;
 
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class ProductDeleteController extends Controller
+class ProductCollectionRestoreController extends Controller
 {
     public function __invoke(string $code): bool
     {
-        return Product::delete($code, true);
+        return Product::collection()->restore($code);
     }
 }

--- a/src/Controllers/ProductCollection/ProductCollectionTrashController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionTrashController.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Gildsmith\Product\Controllers\Product;
+namespace Gildsmith\Product\Controllers\ProductCollection;
 
 use Gildsmith\Support\Facades\Product;
 use Illuminate\Routing\Controller;
 
-class ProductDeleteController extends Controller
+class ProductCollectionTrashController extends Controller
 {
     public function __invoke(string $code): bool
     {
-        return Product::delete($code, true);
+        return Product::collection()->delete($code);
     }
 }

--- a/src/Controllers/ProductCollection/ProductCollectionTrashedController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionTrashedController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gildsmith\Product\Controllers\ProductCollection;
+
+use Gildsmith\Support\Facades\Product;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Collection;
+
+class ProductCollectionTrashedController extends Controller
+{
+    public function __invoke(): Collection
+    {
+        return Product::collection()->trashed();
+    }
+}

--- a/tests/Feature/AttributeController.test.php
+++ b/tests/Feature/AttributeController.test.php
@@ -49,6 +49,26 @@ it('updates an attribute', function () {
     $this->assertDatabaseHas('attributes', ['code' => $attribute->code, 'name->en' => 'Updated']);
 });
 
+it('trashes an attribute', function () {
+    $attribute = Attribute::factory()->create();
+
+    $response = $this->postJson("/attributes/{$attribute->code}/trash");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertSoftDeleted('attributes', ['code' => $attribute->code]);
+});
+
+it('restores an attribute', function () {
+    $attribute = Attribute::factory()->create();
+    $this->postJson("/attributes/{$attribute->code}/trash");
+
+    $response = $this->postJson("/attributes/{$attribute->code}/restore");
+
+    $response->assertOk();
+    $this->assertDatabaseHas('attributes', ['code' => $attribute->code, 'deleted_at' => null]);
+});
+
 it('deletes an attribute', function () {
     $attribute = Attribute::factory()->create();
 
@@ -56,5 +76,5 @@ it('deletes an attribute', function () {
 
     $response->assertOk();
     expect($response->json())->toEqual(true);
-    $this->assertSoftDeleted('attributes', ['code' => $attribute->code]);
+    $this->assertDatabaseMissing('attributes', ['code' => $attribute->code]);
 });

--- a/tests/Feature/AttributeValueController.test.php
+++ b/tests/Feature/AttributeValueController.test.php
@@ -61,6 +61,26 @@ it('updates an attribute value', function () {
     $this->assertDatabaseHas('attribute_values', ['code' => $value->code, 'name->en' => 'Updated']);
 });
 
+it('trashes an attribute value', function () {
+    $value = AttributeValue::factory()->for(Attribute::factory())->create();
+
+    $response = $this->postJson("/attributes/{$value->attribute->code}/values/{$value->code}/trash");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertSoftDeleted('attribute_values', ['code' => $value->code]);
+});
+
+it('restores an attribute value', function () {
+    $value = AttributeValue::factory()->for(Attribute::factory())->create();
+    $this->postJson("/attributes/{$value->attribute->code}/values/{$value->code}/trash");
+
+    $response = $this->postJson("/attributes/{$value->attribute->code}/values/{$value->code}/restore");
+
+    $response->assertOk();
+    $this->assertDatabaseHas('attribute_values', ['code' => $value->code, 'deleted_at' => null]);
+});
+
 it('deletes an attribute value', function () {
     $value = AttributeValue::factory()->for(Attribute::factory())->create();
 
@@ -68,5 +88,5 @@ it('deletes an attribute value', function () {
 
     $response->assertOk();
     expect($response->json())->toEqual(true);
-    $this->assertSoftDeleted('attribute_values', ['code' => $value->code]);
+    $this->assertDatabaseMissing('attribute_values', ['code' => $value->code]);
 });

--- a/tests/Feature/BlueprintController.test.php
+++ b/tests/Feature/BlueprintController.test.php
@@ -43,6 +43,26 @@ it('updates a blueprint', function () {
     $this->assertDatabaseHas('blueprints', ['code' => $blueprint->code, 'name->en' => 'Updated']);
 });
 
+it('trashes a blueprint', function () {
+    $blueprint = Blueprint::factory()->create();
+
+    $response = $this->postJson("/blueprints/{$blueprint->code}/trash");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertSoftDeleted('blueprints', ['code' => $blueprint->code]);
+});
+
+it('restores a blueprint', function () {
+    $blueprint = Blueprint::factory()->create();
+    $this->postJson("/blueprints/{$blueprint->code}/trash");
+
+    $response = $this->postJson("/blueprints/{$blueprint->code}/restore");
+
+    $response->assertOk();
+    $this->assertDatabaseHas('blueprints', ['code' => $blueprint->code, 'deleted_at' => null]);
+});
+
 it('deletes a blueprint', function () {
     $blueprint = Blueprint::factory()->create();
 

--- a/tests/Feature/ProductCollectionController.test.php
+++ b/tests/Feature/ProductCollectionController.test.php
@@ -44,6 +44,26 @@ it('updates a product collection', function () {
     $this->assertDatabaseHas('product_collections', ['code' => $collection->code, 'name->en' => 'Updated']);
 });
 
+it('trashes a product collection', function () {
+    $collection = ProductCollection::factory()->create();
+
+    $response = $this->postJson("/collections/{$collection->code}/trash");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertSoftDeleted('product_collections', ['code' => $collection->code]);
+});
+
+it('restores a product collection', function () {
+    $collection = ProductCollection::factory()->create();
+    $this->postJson("/collections/{$collection->code}/trash");
+
+    $response = $this->postJson("/collections/{$collection->code}/restore");
+
+    $response->assertOk();
+    $this->assertDatabaseHas('product_collections', ['code' => $collection->code, 'deleted_at' => null]);
+});
+
 it('deletes a product collection', function () {
     $collection = ProductCollection::factory()->create();
 

--- a/tests/Feature/ProductController.test.php
+++ b/tests/Feature/ProductController.test.php
@@ -17,3 +17,33 @@ it('returns 404 when product is missing', function () {
 
     $response->assertNotFound();
 });
+
+it('trashes a product', function () {
+    $product = Product::factory()->create();
+
+    $response = $this->postJson("/products/{$product->code}/trash");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertSoftDeleted('products', ['code' => $product->code]);
+});
+
+it('restores a product', function () {
+    $product = Product::factory()->create();
+    $this->postJson("/products/{$product->code}/trash");
+
+    $response = $this->postJson("/products/{$product->code}/restore");
+
+    $response->assertOk();
+    $this->assertDatabaseHas('products', ['code' => $product->code, 'deleted_at' => null]);
+});
+
+it('deletes a product', function () {
+    $product = Product::factory()->create();
+
+    $response = $this->deleteJson("/products/{$product->code}");
+
+    $response->assertOk();
+    expect($response->json())->toEqual(true);
+    $this->assertDatabaseMissing('products', ['code' => $product->code]);
+});


### PR DESCRIPTION
## Summary
- add `/trash`, `/restore`, and `/trashed` routes for products, attributes, attribute values, blueprints, and collections
- default resource `DELETE` endpoints permanently remove records
- expand feature tests for trashing, restoring, and deleting models

## Testing
- `vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_6895652cb2708320a2bbf184bac5da5f