### PR TITLE
Remove unguarded model creation

### DIFF
--- a/src/Controllers/Attribute/AttributeCreateController.php
+++ b/src/Controllers/Attribute/AttributeCreateController.php
@@ -6,7 +6,6 @@ namespace Gildsmith\Product\Controllers\Attribute;
 
 use Gildsmith\Contract\Product\AttributeInterface;
 use Gildsmith\Support\Facades\Product;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
@@ -14,6 +13,6 @@ class AttributeCreateController extends Controller
 {
     public function __invoke(Request $request): AttributeInterface
     {
-        return Model::unguarded(fn () => Product::attribute()->create($request->all()));
+        return Product::attribute()->create($request->all());
     }
 }

--- a/src/Controllers/Blueprint/BlueprintCreateController.php
+++ b/src/Controllers/Blueprint/BlueprintCreateController.php
@@ -6,7 +6,6 @@ namespace Gildsmith\Product\Controllers\Blueprint;
 
 use Gildsmith\Contract\Product\BlueprintInterface;
 use Gildsmith\Support\Facades\Product;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
@@ -14,6 +13,6 @@ class BlueprintCreateController extends Controller
 {
     public function __invoke(Request $request): BlueprintInterface
     {
-        return Model::unguarded(fn () => Product::blueprint()->create($request->all()));
+        return Product::blueprint()->create($request->all());
     }
 }

--- a/src/Controllers/ProductCollection/ProductCollectionCreateController.php
+++ b/src/Controllers/ProductCollection/ProductCollectionCreateController.php
@@ -6,7 +6,6 @@ namespace Gildsmith\Product\Controllers\ProductCollection;
 
 use Gildsmith\Contract\Product\ProductCollectionInterface;
 use Gildsmith\Support\Facades\Product;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 
@@ -14,6 +13,6 @@ class ProductCollectionCreateController extends Controller
 {
     public function __invoke(Request $request): ProductCollectionInterface
     {
-        return Model::unguarded(fn () => Product::collection()->create($request->all()));
+        return Product::collection()->create($request->all());
     }
 }

--- a/src/Models/Attribute.php
+++ b/src/Models/Attribute.php
@@ -26,7 +26,7 @@ class Attribute extends Model implements AttributeInterface
 
     public array $translatable = ['name'];
 
-    protected $fillable = ['name'];
+    protected $fillable = ['code', 'name'];
 
     public $timestamps = false;
 

--- a/src/Models/Blueprint.php
+++ b/src/Models/Blueprint.php
@@ -28,7 +28,7 @@ class Blueprint extends Model implements BlueprintInterface
 
     protected array $translatable = ['name'];
 
-    protected $fillable = ['name'];
+    protected $fillable = ['code', 'name'];
 
     public array $rules = [
         'code' => ValidationRules::CODE,

--- a/src/Models/ProductCollection.php
+++ b/src/Models/ProductCollection.php
@@ -24,7 +24,7 @@ class ProductCollection extends Model implements ProductCollectionInterface
 
     protected array $translatable = ['name'];
 
-    protected $fillable = ['name', 'type'];
+    protected $fillable = ['code', 'name', 'type'];
 
     public array $rules = [
         'code' => ValidationRules::CODE,


### PR DESCRIPTION
## Summary
- Avoid Model::unguarded in attribute, blueprint, and product collection controllers
- Allow mass assignment of `code` attribute on Attribute, Blueprint, and ProductCollection models

## Testing
- `vendor/bin/pint`
- `composer lint` *(fails: At least one path must be specified to analyse)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b910a746bc8320aedfb957f679cda0